### PR TITLE
Change from 'spawn' call to 'exec' call.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 import path from 'path'
-import {spawn, spawnSync} from 'child_process'
+import {exec, spawnSync} from 'child_process'
 
 export default class WebpackNightWatchPlugin {
 
@@ -18,7 +18,7 @@ export default class WebpackNightWatchPlugin {
 
     compiler.plugin(this.options.onEmit ? 'emit' : 'done', (compilation, callback) => {
       const env = Object.assign({}, process.env, {LANG: 'en_US.UTF-8'})
-      const nightwatch = spawn(path.join(__dirname, '../node_modules/.bin/nightwatch'), [
+      const nightwatch = exec(path.join(__dirname, '../node_modules/.bin/nightwatch'), [
         '-c',
         this.options.url
       ], {env})


### PR DESCRIPTION
Hi @wi2,
In my own project I used webpack@2.3.2 + typescript@2.2.2 + nightwatch@0.9.14. And I have an error using your plugin. After deep investigation, I found that the error was raised in 'spawn' call. Changing it to 'exec' call was fixed my problem. So, I'm asking you to commit my changes to master.